### PR TITLE
Geometry Support in Commit/Gen

### DIFF
--- a/generic.js
+++ b/generic.js
@@ -259,6 +259,8 @@ export default class Generic {
 
         if (schema.type === 'array') {
             return sql.array(value, schema.$comment.replace('[', '').replace(']', ''));
+        } else if (schema.$comment === 'geometry' && typeof value === 'object') {
+            return sql`ST_GeomFromGeoJSON(${JSON.stringify(value)})`;
         } else if (schema.$comment === 'timestamp' && value instanceof Date) {
             return sql.timestamp(value);
         } else if (schema.$comment === 'timestamp' && !isNaN(parseInt(value))) {

--- a/test/base.js
+++ b/test/base.js
@@ -3,3 +3,7 @@ import Generic from '../generic.js';
 export class Dog extends Generic {
     static _table = 'dog';
 }
+
+export class Point extends Generic {
+    static _table = 'point';
+}

--- a/test/geometry.test.js
+++ b/test/geometry.test.js
@@ -1,0 +1,84 @@
+import test from 'tape';
+import { sql } from 'slonik';
+import { Point } from './base.js';
+import { Pool } from '../generic.js';
+
+import prep from './prep.js';
+prep(test);
+
+test('Create Table', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    try {
+        await pool.query(sql`
+            CREATE TABLE point (
+                id          BIGSERIAL,
+                name        TEXT NOT NULL UNIQUE,
+                geom        GEOMETRY(GEOMETRY, 4326)
+            );
+        `);
+
+        await pool.query(sql`
+            INSERT INTO point (
+                name,
+                geom
+            ) VALUES (
+                'prairie',
+                ST_GeomFromGeoJSON('{"type":"Point","coordinates":[-102.65,40.17]}')
+            );
+        `);
+    } catch (err) {
+        t.error(err);
+    }
+
+    await pool.end();
+    t.end();
+});
+
+test('Geometry - With Parsing', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic', {
+        parsing: {
+            geometry: true
+        }
+    });
+
+    try {
+        const pt = await Point.from(pool, 1);
+
+        t.equals(pt.id, 1);
+        t.equals(pt.name, 'prairie');
+        t.deepEquals(pt.geom, {
+            type: 'Point',
+            coordinates: [ -102.65, 40.17 ],
+            bounds: [ -102.65, 40.17, -102.65, 40.17 ]
+        });
+
+    } catch (err) {
+        t.error(err);
+    }
+
+    await pool.end();
+    t.end();
+});
+
+test('Geometry - Without Parsing', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic', {
+        parsing: {
+            geometry: false
+        }
+    });
+
+    try {
+        const pt = await Point.from(pool, 1);
+
+        t.equals(pt.id, 1);
+        t.equals(pt.name, 'prairie');
+        t.equals(pt.geom, '0101000020E61000009A99999999A959C0F6285C8FC2154440');
+
+    } catch (err) {
+        t.error(err);
+    }
+
+    await pool.end();
+    t.end();
+});

--- a/test/geometry.test.js
+++ b/test/geometry.test.js
@@ -49,8 +49,8 @@ test('Geometry - With Parsing', async (t) => {
         t.equals(pt.name, 'prairie');
         t.deepEquals(pt.geom, {
             type: 'Point',
-            coordinates: [ -102.65, 40.17 ],
-            bounds: [ -102.65, 40.17, -102.65, 40.17 ]
+            coordinates: [-102.65, 40.17],
+            bounds: [-102.65, 40.17, -102.65, 40.17]
         });
 
     } catch (err) {


### PR DESCRIPTION
### Context

Objects passed into commit/generate that are destined for a `geometry` table are assumed to be GeoJSON and parsed automatically.