### PR TITLE
Schema.from

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,3 +1,4 @@
+import Err from '@openaddresses/batch-error';
 import mkdirp from 'mkdirp';
 import path from 'path';
 import fs from 'fs/promises';
@@ -6,6 +7,24 @@ import fs from 'fs/promises';
  * @class
  */
 export default class Schema {
+    /**
+     * Given a class or instance that extends generic, return a cloned schema
+     *
+     * @param {Pool} pool Batch Generic Postgres Pool
+     * @param {Generic} cls Class which extends generic
+     *
+     * @returns {Object} JSON Schema
+     */
+    static from(pool, cls) {
+        const table = cls._table;
+        if (!table) throw new Err(500, null, 'Cannot use Schema.from(..) on instance/class that does not extend Generic');
+
+        const schema = pool._schemas.tables[table];
+        if (!schema) throw new Err(500, null, `The schema for the table "${table}" could not be found`);
+
+        return JSON.parse(JSON.stringify(pool._schemas.tables[table]));
+    }
+
     static async write(schemas, dir) {
         if (dir instanceof URL) dir = dir.pathname;
         else dir = String(dir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@openaddresses/batch-generic",
-    "version": "10.3.1",
+    "version": "11.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@openaddresses/batch-generic",
-            "version": "10.3.1",
+            "version": "11.2.0",
             "license": "ISC",
             "dependencies": {
                 "@openaddresses/batch-error": "^1.0.1",
@@ -404,9 +404,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-            "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+            "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -681,9 +681,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.7.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-            "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+            "version": "18.7.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+            "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -712,42 +712,42 @@
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.38.tgz",
-            "integrity": "sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
+            "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
             "dev": true,
             "optional": true,
             "dependencies": {
                 "@babel/parser": "^7.16.4",
-                "@vue/shared": "3.2.38",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.38.tgz",
-            "integrity": "sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.39.tgz",
+            "integrity": "sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "@vue/compiler-core": "3.2.38",
-                "@vue/shared": "3.2.38"
+                "@vue/compiler-core": "3.2.39",
+                "@vue/shared": "3.2.39"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.38.tgz",
-            "integrity": "sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.39.tgz",
+            "integrity": "sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==",
             "dev": true,
             "optional": true,
             "dependencies": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.38",
-                "@vue/compiler-dom": "3.2.38",
-                "@vue/compiler-ssr": "3.2.38",
-                "@vue/reactivity-transform": "3.2.38",
-                "@vue/shared": "3.2.38",
+                "@vue/compiler-core": "3.2.39",
+                "@vue/compiler-dom": "3.2.39",
+                "@vue/compiler-ssr": "3.2.39",
+                "@vue/reactivity-transform": "3.2.39",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
@@ -755,34 +755,34 @@
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.38.tgz",
-            "integrity": "sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.39.tgz",
+            "integrity": "sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "@vue/compiler-dom": "3.2.38",
-                "@vue/shared": "3.2.38"
+                "@vue/compiler-dom": "3.2.39",
+                "@vue/shared": "3.2.39"
             }
         },
         "node_modules/@vue/reactivity-transform": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.38.tgz",
-            "integrity": "sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.39.tgz",
+            "integrity": "sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==",
             "dev": true,
             "optional": true,
             "dependencies": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.38",
-                "@vue/shared": "3.2.38",
+                "@vue/compiler-core": "3.2.39",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-            "integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
+            "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
             "dev": true,
             "optional": true
         },
@@ -1092,9 +1092,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001390",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001390.tgz",
-            "integrity": "sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==",
+            "version": "1.0.30001397",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+            "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
             "dev": true,
             "funding": [
                 {
@@ -1524,9 +1524,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.243",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
-            "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
+            "version": "1.4.247",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
+            "integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1645,12 +1645,12 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-            "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+            "version": "8.23.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+            "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.1",
+                "@eslint/eslintrc": "^1.3.2",
                 "@humanwhocodes/config-array": "^0.10.4",
                 "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -1669,7 +1669,6 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^6.0.1",
                 "globals": "^13.15.0",
                 "globby": "^11.1.0",
@@ -1678,6 +1677,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
@@ -2002,9 +2002,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -2185,12 +2185,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-            "dev": true
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
@@ -2825,9 +2819,9 @@
             }
         },
         "node_modules/is-callable": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.5.tgz",
+            "integrity": "sha512-ZIWRujF6MvYGkEuHMYtFRkL2wAtFw89EHfKlXrkPkjQZZRWeh9L1q3SV13NIfHnqxugjLvAOkEHx9mb1zcMnEw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
@@ -3138,6 +3132,12 @@
             "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-1.3.0.tgz",
             "integrity": "sha512-K4CiUBzo3YeWk76FuET/dQPH03WE04R94feo5TSKQCXpoXQt9E4yx2CnY737QZnSAI3PI4WlKo/zfqizGx52QQ==",
             "peer": true
+        },
+        "node_modules/js-sdsl": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+            "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -3470,11 +3470,12 @@
             }
         },
         "node_modules/mdast-util-gfm-table": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.4.tgz",
-            "integrity": "sha512-aEuoPwZyP4iIMkf2cLWXxx3EQ6Bmh2yKy9MVCg4i6Sd3cX80dcLEfXO/V4ul3pGH9czBK4kp+FAl+ZHmSUt9/w==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.6.tgz",
+            "integrity": "sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==",
             "dev": true,
             "dependencies": {
+                "@types/mdast": "^3.0.0",
                 "markdown-table": "^3.0.0",
                 "mdast-util-from-markdown": "^1.0.0",
                 "mdast-util-to-markdown": "^1.3.0"
@@ -5425,9 +5426,9 @@
             }
         },
         "node_modules/slonik": {
-            "version": "31.1.0",
-            "resolved": "https://registry.npmjs.org/slonik/-/slonik-31.1.0.tgz",
-            "integrity": "sha512-n+J1kpcpzEAY9c/0V3GNN9o0uyarZUn/qI7qDuV1GC+vIvd6Iksnw8iyu2QyKJmYaOiXnqsd4Kmga/LaGkNZag==",
+            "version": "31.2.1",
+            "resolved": "https://registry.npmjs.org/slonik/-/slonik-31.2.1.tgz",
+            "integrity": "sha512-yxkHVGpz/Wn+1trwV8Sk5YsQgFWekNC/aVTBkOgpP+qtOPADs9/Qp/uJdxPL1l2h5zS9RuxKazuqr9yv4qEAQw==",
             "peer": true,
             "dependencies": {
                 "concat-stream": "^2.0.0",
@@ -6179,9 +6180,9 @@
             }
         },
         "node_modules/vfile": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.4.tgz",
-            "integrity": "sha512-KI+7cnst03KbEyN1+JE504zF5bJBZa+J+CrevLeyIMq0aPU681I2rQ5p4PlnQ6exFtWiUrg26QUdFMnAKR6PIw==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.5.tgz",
+            "integrity": "sha512-U1ho2ga33eZ8y8pkbQLH54uKqGhFJ6GYIHnnG5AhRpAh3OWjkrRHKa/KogbmQn8We+c0KVV3rTOgR9V/WowbXQ==",
             "dev": true,
             "dependencies": {
                 "@types/unist": "^2.0.0",
@@ -6489,9 +6490,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.0.tgz",
-            "integrity": "sha512-Yw0qvUsCNGBe5YacikdMt5gVYeUuaEFVDIHKMfElrGSaBhwR3CQK6vOzgfAJOjTdGIhEeoaj8GtT+NDZrepZbw==",
+            "version": "3.19.1",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+            "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
             "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -6800,9 +6801,9 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-            "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+            "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -7011,9 +7012,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.7.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
-            "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+            "version": "18.7.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+            "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg=="
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -7042,42 +7043,42 @@
             }
         },
         "@vue/compiler-core": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.38.tgz",
-            "integrity": "sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.39.tgz",
+            "integrity": "sha512-mf/36OWXqWn0wsC40nwRRGheR/qoID+lZXbIuLnr4/AngM0ov8Xvv8GHunC0rKRIkh60bTqydlqTeBo49rlbqw==",
             "dev": true,
             "optional": true,
             "requires": {
                 "@babel/parser": "^7.16.4",
-                "@vue/shared": "3.2.38",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
             }
         },
         "@vue/compiler-dom": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.38.tgz",
-            "integrity": "sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.39.tgz",
+            "integrity": "sha512-HMFI25Be1C8vLEEv1hgEO1dWwG9QQ8LTTPmCkblVJY/O3OvWx6r1+zsox5mKPMGvqYEZa6l8j+xgOfUspgo7hw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "@vue/compiler-core": "3.2.38",
-                "@vue/shared": "3.2.38"
+                "@vue/compiler-core": "3.2.39",
+                "@vue/shared": "3.2.39"
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.38.tgz",
-            "integrity": "sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.39.tgz",
+            "integrity": "sha512-fqAQgFs1/BxTUZkd0Vakn3teKUt//J3c420BgnYgEOoVdTwYpBTSXCMJ88GOBCylmUBbtquGPli9tVs7LzsWIA==",
             "dev": true,
             "optional": true,
             "requires": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.38",
-                "@vue/compiler-dom": "3.2.38",
-                "@vue/compiler-ssr": "3.2.38",
-                "@vue/reactivity-transform": "3.2.38",
-                "@vue/shared": "3.2.38",
+                "@vue/compiler-core": "3.2.39",
+                "@vue/compiler-dom": "3.2.39",
+                "@vue/compiler-ssr": "3.2.39",
+                "@vue/reactivity-transform": "3.2.39",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
@@ -7085,34 +7086,34 @@
             }
         },
         "@vue/compiler-ssr": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.38.tgz",
-            "integrity": "sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.39.tgz",
+            "integrity": "sha512-EoGCJ6lincKOZGW+0Ky4WOKsSmqL7hp1ZYgen8M7u/mlvvEQUaO9tKKOy7K43M9U2aA3tPv0TuYYQFrEbK2eFQ==",
             "dev": true,
             "optional": true,
             "requires": {
-                "@vue/compiler-dom": "3.2.38",
-                "@vue/shared": "3.2.38"
+                "@vue/compiler-dom": "3.2.39",
+                "@vue/shared": "3.2.39"
             }
         },
         "@vue/reactivity-transform": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.38.tgz",
-            "integrity": "sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.39.tgz",
+            "integrity": "sha512-HGuWu864zStiWs9wBC6JYOP1E00UjMdDWIG5W+FpUx28hV3uz9ODOKVNm/vdOy/Pvzg8+OcANxAVC85WFBbl3A==",
             "dev": true,
             "optional": true,
             "requires": {
                 "@babel/parser": "^7.16.4",
-                "@vue/compiler-core": "3.2.38",
-                "@vue/shared": "3.2.38",
+                "@vue/compiler-core": "3.2.39",
+                "@vue/shared": "3.2.39",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
             }
         },
         "@vue/shared": {
-            "version": "3.2.38",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-            "integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+            "version": "3.2.39",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.39.tgz",
+            "integrity": "sha512-D3dl2ZB9qE6mTuWPk9RlhDeP1dgNRUKC3NJxji74A4yL8M2MwlhLKUC/49WHjrNzSPug58fWx/yFbaTzGAQSBw==",
             "dev": true,
             "optional": true
         },
@@ -7317,9 +7318,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001390",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001390.tgz",
-            "integrity": "sha512-sS4CaUM+/+vqQUlCvCJ2WtDlV81aWtHhqeEVkLokVJJa3ViN4zDxAGfq9R8i1m90uGHxo99cy10Od+lvn3hf0g==",
+            "version": "1.0.30001397",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+            "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
             "dev": true
         },
         "ccount": {
@@ -7639,9 +7640,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.243",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
-            "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
+            "version": "1.4.247",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
+            "integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw==",
             "dev": true
         },
         "emoji-regex": {
@@ -7736,12 +7737,12 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-            "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+            "version": "8.23.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.1.tgz",
+            "integrity": "sha512-w7C1IXCc6fNqjpuYd0yPlcTKKmHlHHktRkzmBPZ+7cvNBQuiNjx0xaMTjAJGCafJhQkrFJooREv0CtrVzmHwqg==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.1",
+                "@eslint/eslintrc": "^1.3.2",
                 "@humanwhocodes/config-array": "^0.10.4",
                 "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -7760,7 +7761,6 @@
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
-                "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^6.0.1",
                 "globals": "^13.15.0",
                 "globby": "^11.1.0",
@@ -7769,6 +7769,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
+                "js-sdsl": "^4.1.4",
                 "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
@@ -7990,9 +7991,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-glob": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+            "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -8136,12 +8137,6 @@
                 "es-abstract": "^1.19.0",
                 "functions-have-names": "^1.2.2"
             }
-        },
-        "functional-red-black-tree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-            "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-            "dev": true
         },
         "functions-have-names": {
             "version": "1.2.3",
@@ -8591,9 +8586,9 @@
             "dev": true
         },
         "is-callable": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.5.tgz",
+            "integrity": "sha512-ZIWRujF6MvYGkEuHMYtFRkL2wAtFw89EHfKlXrkPkjQZZRWeh9L1q3SV13NIfHnqxugjLvAOkEHx9mb1zcMnEw==",
             "dev": true
         },
         "is-core-module": {
@@ -8805,6 +8800,12 @@
             "resolved": "https://registry.npmjs.org/iso8601-duration/-/iso8601-duration-1.3.0.tgz",
             "integrity": "sha512-K4CiUBzo3YeWk76FuET/dQPH03WE04R94feo5TSKQCXpoXQt9E4yx2CnY737QZnSAI3PI4WlKo/zfqizGx52QQ==",
             "peer": true
+        },
+        "js-sdsl": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+            "integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -9062,11 +9063,12 @@
             }
         },
         "mdast-util-gfm-table": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.4.tgz",
-            "integrity": "sha512-aEuoPwZyP4iIMkf2cLWXxx3EQ6Bmh2yKy9MVCg4i6Sd3cX80dcLEfXO/V4ul3pGH9czBK4kp+FAl+ZHmSUt9/w==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.6.tgz",
+            "integrity": "sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==",
             "dev": true,
             "requires": {
+                "@types/mdast": "^3.0.0",
                 "markdown-table": "^3.0.0",
                 "mdast-util-from-markdown": "^1.0.0",
                 "mdast-util-to-markdown": "^1.3.0"
@@ -10388,9 +10390,9 @@
             "dev": true
         },
         "slonik": {
-            "version": "31.1.0",
-            "resolved": "https://registry.npmjs.org/slonik/-/slonik-31.1.0.tgz",
-            "integrity": "sha512-n+J1kpcpzEAY9c/0V3GNN9o0uyarZUn/qI7qDuV1GC+vIvd6Iksnw8iyu2QyKJmYaOiXnqsd4Kmga/LaGkNZag==",
+            "version": "31.2.1",
+            "resolved": "https://registry.npmjs.org/slonik/-/slonik-31.2.1.tgz",
+            "integrity": "sha512-yxkHVGpz/Wn+1trwV8Sk5YsQgFWekNC/aVTBkOgpP+qtOPADs9/Qp/uJdxPL1l2h5zS9RuxKazuqr9yv4qEAQw==",
             "peer": true,
             "requires": {
                 "concat-stream": "^2.0.0",
@@ -10948,9 +10950,9 @@
             }
         },
         "vfile": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.4.tgz",
-            "integrity": "sha512-KI+7cnst03KbEyN1+JE504zF5bJBZa+J+CrevLeyIMq0aPU681I2rQ5p4PlnQ6exFtWiUrg26QUdFMnAKR6PIw==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.5.tgz",
+            "integrity": "sha512-U1ho2ga33eZ8y8pkbQLH54uKqGhFJ6GYIHnnG5AhRpAh3OWjkrRHKa/KogbmQn8We+c0KVV3rTOgR9V/WowbXQ==",
             "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
@@ -11191,9 +11193,9 @@
             "dev": true
         },
         "zod": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.0.tgz",
-            "integrity": "sha512-Yw0qvUsCNGBe5YacikdMt5gVYeUuaEFVDIHKMfElrGSaBhwR3CQK6vOzgfAJOjTdGIhEeoaj8GtT+NDZrepZbw==",
+            "version": "3.19.1",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+            "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
             "peer": true
         },
         "zwitch": {

--- a/test/schema#from.test.js
+++ b/test/schema#from.test.js
@@ -1,0 +1,100 @@
+import Schema from '../lib/schema.js';
+import test from 'tape';
+import { Dog } from './base.js';
+import { Pool } from '../generic.js';
+import { sql } from 'slonik';
+
+import prep from './prep.js';
+prep(test);
+
+test('Create Table', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    try {
+        await pool.query(sql`
+            CREATE TABLE dog (
+                id          BIGSERIAL,
+                name        TEXT NOT NULL UNIQUE,
+                species     TEXT NOT NULL DEFAULT 'corgi',
+                loyalty     INTEGER NOT NULL DEFAULT 9,
+                cute        BOOLEAN NOT NULL DEFAULT False,
+                smart       BIGINT NOT NULL DEFAULT 99,
+                attr        JSON NOT NULL DEFAULT '{}'::JSON,
+                created     TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated     TIMESTAMP NOT NULL DEFAULT NOW()
+            );
+        `);
+    } catch (err) {
+        t.error(err);
+    }
+
+    await pool.end();
+    t.end();
+});
+
+test('Schema#from - class retrieval', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    t.deepEquals(Object.keys(Schema.from(pool, Dog)).sort(), [
+        'type',
+        'additionalProperties',
+        'properties',
+        'required'
+    ].sort());
+
+    t.end();
+});
+
+test('Schema#from - instance retrieval', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    try {
+        const dog = await Dog.generate(pool, {
+            name: 'prairie',
+            species: 'mutt',
+            loyalty: 10,
+            cute: true,
+            smart: 100,
+            attr: {}
+        });
+
+        t.deepEquals(Object.keys(Schema.from(pool, dog)).sort(), [
+            'type',
+            'additionalProperties',
+            'properties',
+            'required'
+        ].sort());
+    } catch (err) {
+        t.error(err);
+    }
+
+    t.end();
+});
+
+test('Schema#from - non-generic', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    try {
+        Schema.from(pool, {});
+        t.fail();
+    } catch (err) {
+        t.equals(err.safe, 'Cannot use Schema.from(..) on instance/class that does not extend Generic');
+    }
+
+    t.end();
+});
+
+test('Schema#from - table doesn\'t exist', async (t) => {
+    const pool = await Pool.connect(process.env.POSTGRES || 'postgres://postgres@localhost:5432/batch_generic');
+
+    try {
+        Schema.from(pool, {
+            _table: 'fake'
+        });
+        t.fail();
+    } catch (err) {
+        t.equals(err.safe, 'The schema for the table "fake" could not be found');
+    }
+
+    t.end();
+});


### PR DESCRIPTION
### Context

It isn't uncommon for the caller to also want to be able to see the schema. At the moment this can be done with a knowledge of the internals of Batch-Generic but this is verbose and subject to change.

This PR introduces Schema.from which returns a schema given the database pool & an instance or class that extends generic.

```js
import { Schema } from '@openaddresses/batch-schema';

const jsonschema = Schema.from(pool, User);
```